### PR TITLE
Implement active user cursors

### DIFF
--- a/public/stylesheets/riht.css
+++ b/public/stylesheets/riht.css
@@ -1,5 +1,19 @@
 :root{
   --offwhite: #f0f0f0;
+  --light-blue: #a1f4ff;
+  --dark-blue: #00aaff;
+  --pink: #ff6e8b;
+  --salmon: #ff5e5e;
+  --red: #e60000;
+  --mustard: #ffe100;
+  --light-orange: #ffae00;
+  --dark-orange: #ff6f00;
+  --light-green: #25e873;
+  --dark-green: #007d11;
+  --olive: #738f51;
+  --seafoam: #71eeb8;
+  --light-purple: #ae4aff;
+  --dark-purple: #804aff;
 }
 
 * {
@@ -70,4 +84,11 @@ h2 {
 
 .active {
   background-color: var(--offwhite);
+}
+
+.cursor {
+  display: inline-block;
+  vertical-align: bottom;
+  width: 2px;
+  height: 1.25em;
 }

--- a/src/components/conversation/Conversation.vue
+++ b/src/components/conversation/Conversation.vue
@@ -23,7 +23,7 @@
 
 <script>
 import handlers from './handlers';
-import { GOING_AWAY } from './constants';
+import { GOING_AWAY, userColours } from './constants';
 
 const data = () => ({
   ws: null,
@@ -34,6 +34,7 @@ const data = () => ({
   patchBuffer: [],
   activeUsers: {},
   cursorPosition: 0,
+  colourList: userColours.slice(),
 });
 
 /* Vue instance computed functions */
@@ -52,12 +53,11 @@ function activeConversation() {
 /* Vue instance lifecycle hooks */
 function created() {
   this.conversation = this.conversations[this.activeConversation];
-  this.connectWebSocket();
 }
 
 function mounted() {
   this.conversationDOM = this.$el.querySelector('#conversation-body');
-  this.conversationDOM.innerHTML = this.content;
+  this.connectWebSocket();
 }
 
 export default {

--- a/src/components/conversation/constants.js
+++ b/src/components/conversation/constants.js
@@ -16,6 +16,23 @@ const cursorProps = Object.freeze(['type', 'user_id', 'cursor_delta']);
 const ackProps = Object.freeze(['version']);
 const userActionProps = Object.freeze(['user_id']);
 
+const userColours = Object.freeze([
+  'light-blue',
+  'dark-blue',
+  'pink',
+  'salmon',
+  'red',
+  'mustard',
+  'light-orange',
+  'dark-orange',
+  'light-green',
+  'dark-green',
+  'olive',
+  'seafoam',
+  'light-purple',
+  'dark-purple',
+]);
+
 // WebSocket error codes
 const GOING_AWAY = 4001;
 const INVALID_PAYLOAD_DATA = 4007;
@@ -39,6 +56,7 @@ export {
   cursorProps,
   ackProps,
   userActionProps,
+  userColours,
   GOING_AWAY,
   INVALID_PAYLOAD_DATA,
   INTERNAL_ERROR,

--- a/src/components/conversation/cursor.js
+++ b/src/components/conversation/cursor.js
@@ -102,7 +102,6 @@ const setCaretPosition = (el, position) => {
     colour, string: the colour to use for the caret
 */
 const setActiveUserCaretPosition = (el, position, id, colour) => {
-  console.log(position, id, colour);
   const cd = getCaretData(el, position);
   let cursor = el.querySelector(`#user-${id}`);
   if (cursor === null) {

--- a/src/components/conversation/cursor.js
+++ b/src/components/conversation/cursor.js
@@ -74,24 +74,56 @@ const getCaretData = (el, position) => {
 /*
   Sets the caret position.
   Parameters:
-    d, Object{node, offset}: where node is the Node that contains the caret and
-      offset is the position within the Node
     el, DOM Element: the element that contains the Node
     position, int: the desired position
 */
-const setCaretPosition = (d, el) => {
+const setCaretPosition = (el, position) => {
   const doc = el.ownerDocument || el.document;
   const win = doc.defaultView || doc.parentWindow;
   const sel = win.getSelection();
   const range = doc.createRange();
-  range.setStart(d.node, d.offset);
+
+  const cd = getCaretData(el, position);
+  if (cd.node === undefined) {
+    cd.node = el;
+  }
+  range.setStart(cd.node, cd.offset);
   range.collapse(true);
   sel.removeAllRanges();
   sel.addRange(range);
 };
 
+/*
+  Sets the active user's displayed caret position.
+  Parameters:
+    el, DOM Element: the element that contains the Node
+    position, int: the desired position
+    id, int: the active user's id
+    colour, string: the colour to use for the caret
+*/
+const setActiveUserCaretPosition = (el, position, id, colour) => {
+  console.log(position, id, colour);
+  const cd = getCaretData(el, position);
+  let cursor = el.querySelector(`#user-${id}`);
+  if (cursor === null) {
+    cursor = document.createElement('div');
+    cursor.setAttribute('id', `user-${id}`);
+    cursor.setAttribute('class', 'cursor');
+    cursor.setAttribute('style', `background-color: var(--${colour});`);
+  } else {
+    cursor = cursor.parentNode.removeChild(cursor);
+  }
+
+  if (cd.node !== undefined) {
+    const newNode = cd.node.splitText(cd.offset);
+    newNode.parentNode.insertBefore(cursor, newNode);
+  } else {
+    el.append(cursor, document.createTextNode(''));
+  }
+};
+
 export {
   getCaretPosition,
-  getCaretData,
   setCaretPosition,
+  setActiveUserCaretPosition,
 };


### PR DESCRIPTION
Resolves #13.

Pretty much active users' cursors are just inline with the text.

An active user's cursor is added to the DOM with a randomly generated cursor colour when the client gets the initial message from the server and whenever the client receives a `UserJoin` message. An active user's cursor is removed from the DOM when the client receives a `UserLeave` message. 

Whenever the client is sending a patch, all the cursors are removed, the patch is generated, the new active user cursor positions are calculated, and then the cursors are set again.