### PR TITLE
Implement various fixes

### DIFF
--- a/src/components/Conversation.vue
+++ b/src/components/Conversation.vue
@@ -70,7 +70,6 @@ export default {
   watch: {
     activeConversation() {
       const el = new DOMElement(this.$el.querySelector('#conversation-body'));
-      console.log(`activeConversation: ${this.activeConversation}`);
       if (this.conversation.ws) {
         this.close(WSException.GOING_AWAY);
       }

--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -36,12 +36,18 @@ import More from '../assets/more_vert-24px.svg';
 const data = () => ({
   more: false,
   createConversation: false,
+  intervalID: 0,
 });
 
 function created() {
   this.getAll();
   this.getUser();
-  window.setInterval(this.updateDisplayTime, 60000);
+  this.intervalID = window.setInterval(this.updateDisplayTime, 60000);
+}
+
+function destroyed() {
+  // Stop updating conversation display times
+  window.clearInterval(this.intervalID);
 }
 
 export default {
@@ -55,6 +61,7 @@ export default {
   },
   data,
   created,
+  destroyed,
   computed: {
     ...mapState('user', ['user']),
     ...mapState('conversations', ['conversationsSorted']),

--- a/src/services/models/update.js
+++ b/src/services/models/update.js
@@ -65,15 +65,11 @@ class Update extends WSMessage {
       delta,
     );
 
-    console.log(selfCaret);
-
     // Shift client checkpoint caret
     if (selfCaret) {
       newCheckpoint.selfCaret.shiftCaret(senderCaret, delta);
       selfCaret = newCheckpoint.selfCaret.copy();
     }
-
-    console.log(selfCaret);
 
     // Shift active users' checkpoint carets
     Object.entries(newCheckpoint.activeUsers).forEach(([user, caret]) => {
@@ -85,8 +81,8 @@ class Update extends WSMessage {
       } else {
         newCaret.shiftCaret(senderCaret, delta);
       }
-      newCheckpoint.activeUsers[user] = newCaret;
-      state.activeUsers[user].caret = newCaret;
+      newCheckpoint.activeUsers[user] = newCaret.copy();
+      state.activeUsers[user].caret = newCaret.copy();
     });
 
     // Add new version checkpoint

--- a/src/services/models/wsmessage.js
+++ b/src/services/models/wsmessage.js
@@ -30,6 +30,7 @@ class WSMessage {
   *   ws: WebSocket
   */
   send(ws) {
+    console.log(this);
     ws.send(this.toString());
   }
 

--- a/src/store/conversations.js
+++ b/src/store/conversations.js
@@ -414,6 +414,10 @@ const closeSuccess = (currState, e) => {
   console.log(`Closed WebSocket connection for conversation ${currState.conversation.metadata.id}: ${e.reason}`);
 
   const newState = currState;
+  Object.values(newState.conversation.activeUsers).forEach((activeUser) => {
+    newState.conversation.el.removeActiveUserCaret(activeUser);
+  });
+
   newState.conversation = { ...conversationState };
 };
 


### PR DESCRIPTION
* Fix issue of active users' carets being moved incorrectly which was caused by the active user's caret being stored by reference in a checkpoint instead of copied by value
* Fix issue of active user carets from a previous conversation remaining in the DOM when opening a new conversation
* Remove unnecessary logs