### PR TITLE
Handle new lines properly

### DIFF
--- a/src/services/models/domElement.js
+++ b/src/services/models/domElement.js
@@ -94,6 +94,10 @@ class DOMElement {
     return a;
   }
 
+  /**
+   * getAllDivNodes gets all of the <div> nodes within the DOM Element.
+   * Returns: Node[]
+   */
   getAllDivNodes() {
     const allNodes = this.getAllNodes();
     return allNodes.filter((node) => node.nodeName.toUpperCase() === 'DIV');
@@ -142,7 +146,7 @@ class DOMElement {
       }
     }
 
-    return { node, offset, newLines: divCount };
+    return { node, offset };
   }
 
   /**

--- a/src/services/models/domElement.js
+++ b/src/services/models/domElement.js
@@ -61,24 +61,19 @@ class DOMElement {
         // preceding and including the range's start container and end
         // container.
         const divs = this.getAllDivNodes();
-        let startCount = 0;
-        let endCount = 0;
+        divs.splice(0, 1); // The first div doesn't count as a new line
         divs.forEach((child) => {
           const relativeToStart = range.startContainer.compareDocumentPosition(child);
           const relativeToEnd = range.endContainer.compareDocumentPosition(child);
           if (relativeToStart === 0
             || relativeToStart & Node.DOCUMENT_POSITION_PRECEDING) {
             start += 1;
-            startCount += 1;
           }
           if (relativeToEnd === 0
             || relativeToEnd & Node.DOCUMENT_POSITION_PRECEDING) {
             end += 1;
-            endCount += 1;
           }
         });
-        console.log(startCount);
-        console.log(endCount);
       }
     }
     return new Caret(start, end);
@@ -129,6 +124,7 @@ class DOMElement {
     const divs = this.getAllDivNodes();
     let divCount = 0;
 
+    offset += 1; // Account for the div on the first line
     for (let n = 0; n < nodes.length; n += 1) {
       if (nodes[n].isEqualNode(divs[divCount])) {
         offset -= 1;
@@ -229,18 +225,16 @@ class DOMElement {
     }
     const range = document.createRange();
     range.setStart(startData.node, startData.offset);
-    const startY = range.getBoundingClientRect().top;
-    const startX = range.getBoundingClientRect().left;
+    let startY = range.getBoundingClientRect().top;
+    let startX = range.getBoundingClientRect().left;
 
     if (startY === 0 && startX === 0) {
-      parentNode.style.position = 'relative';
-      cursor.style.top = '1em';
-      cursor.style.left = '1em';
-    } else {
-      parentNode.style.position = 'static';
-      cursor.style.top = `${startY}px`;
-      cursor.style.left = `${startX}px`;
+      startY = startData.node.parentNode.getBoundingClientRect().top;
+      startX = startData.node.parentNode.getBoundingClientRect().left;
     }
+    parentNode.style.position = 'static';
+    cursor.style.top = `${startY}px`;
+    cursor.style.left = `${startX}px`;
 
     parentNode.append(cursor);
 

--- a/src/services/models/domElement.js
+++ b/src/services/models/domElement.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-bitwise */
+/* eslint-disable no-continue */
 import Caret from './caret';
 
 class DOMElement {
@@ -61,7 +62,9 @@ class DOMElement {
         // preceding and including the range's start container and end
         // container.
         const divs = this.getAllDivNodes();
-        divs.splice(0, 1); // The first div doesn't count as a new line
+        if (divs.length > 0) {
+          divs.splice(0, 1); // The first div doesn't count as a new line
+        }
         divs.forEach((child) => {
           const relativeToStart = range.startContainer.compareDocumentPosition(child);
           const relativeToEnd = range.endContainer.compareDocumentPosition(child);
@@ -110,7 +113,8 @@ class DOMElement {
   getTextSize() {
     const range = document.createRange();
     range.selectNodeContents(this.el);
-    return range.toString().length + this.getAllDivNodes().length;
+    const divs = this.getAllDivNodes();
+    return range.toString().length + (divs.length > 0 ? divs.length - 1 : 0);
   }
 
   /**
@@ -128,12 +132,14 @@ class DOMElement {
     const divs = this.getAllDivNodes();
     let divCount = 0;
 
-    offset += 1; // Account for the div on the first line
+    if (divs.length > 0) {
+      offset += 1; // Account for the div on the first line
+    }
     for (let n = 0; n < nodes.length; n += 1) {
       if (nodes[n].isEqualNode(divs[divCount])) {
         offset -= 1;
-        n += 1;
         divCount += 1;
+        continue;
       }
 
       const nodeValue = nodes[n].nodeValue ? nodes[n].nodeValue : '';
@@ -232,13 +238,19 @@ class DOMElement {
     let startY = range.getBoundingClientRect().top;
     let startX = range.getBoundingClientRect().left;
 
-    if (startY === 0 && startX === 0) {
-      startY = startData.node.parentNode.getBoundingClientRect().top;
-      startX = startData.node.parentNode.getBoundingClientRect().left;
+    if (startData.node === this.el) {
+      parentNode.style.position = 'relative';
+      cursor.style.top = '1em';
+      cursor.style.left = '1em';
+    } else {
+      if (startY === 0 && startX === 0) {
+        startY = startData.node.getBoundingClientRect().top;
+        startX = startData.node.getBoundingClientRect().left;
+      }
+      parentNode.style.position = 'static';
+      cursor.style.top = `${startY}px`;
+      cursor.style.left = `${startX}px`;
     }
-    parentNode.style.position = 'static';
-    cursor.style.top = `${startY}px`;
-    cursor.style.left = `${startX}px`;
 
     parentNode.append(cursor);
 

--- a/src/services/models/init.js
+++ b/src/services/models/init.js
@@ -42,6 +42,9 @@ class Init extends WSMessage {
     state.checkpoint.latest = state.version;
     state.caret = new Caret(0, 0);
     state.checkpoint.version[state.version] = new Checkpoint(state.caret, {});
+    if (state.content === '') {
+      state.content = '<div></div';
+    }
     state.el.setInnerHTML(state.content);
     state.textSize = state.el.getTextSize();
 

--- a/src/services/models/init.js
+++ b/src/services/models/init.js
@@ -42,9 +42,6 @@ class Init extends WSMessage {
     state.checkpoint.latest = state.version;
     state.caret = new Caret(0, 0);
     state.checkpoint.version[state.version] = new Checkpoint(state.caret, {});
-    if (state.content === '') {
-      state.content = '<div></div';
-    }
     state.el.setInnerHTML(state.content);
     state.textSize = state.el.getTextSize();
 

--- a/src/store/conversations.js
+++ b/src/store/conversations.js
@@ -348,6 +348,8 @@ const handleInput = (currState) => {
 
   if (content === '' || content === '<br>') {
     el.setInnerHTML(`<div>${el.innerHTML}</div>`);
+    const newTextSize = el.getTextSize();
+    el.setCaret({ start: newTextSize, end: newTextSize });
   }
   const patches = dmp.patch_make(content, el.innerHTML);
 
@@ -421,7 +423,7 @@ const closeSuccess = (currState, e) => {
 
   const newState = currState;
   Object.values(newState.conversation.activeUsers).forEach((activeUser) => {
-    newState.conversation.el.removeActiveUserCaret(activeUser);
+    newState.conversation.el.removeActiveUserCaret(activeUser.id);
   });
 
   newState.conversation = { ...conversationState };

--- a/src/store/conversations.js
+++ b/src/store/conversations.js
@@ -346,6 +346,9 @@ const handleInput = (currState) => {
 
   el.removeAllHighlights();
 
+  if (content === '' || content === '<br>') {
+    el.setInnerHTML(`<div>${el.innerHTML}</div>`);
+  }
   const patches = dmp.patch_make(content, el.innerHTML);
 
   const newCaret = el.getCaretPosition();

--- a/src/store/conversations.js
+++ b/src/store/conversations.js
@@ -358,6 +358,7 @@ const handleInput = (currState) => {
   );
 
   // Send an Edit Update message for each patch
+  let firstPatch = true;
   patches.forEach((patch) => {
     version += 1;
 
@@ -366,15 +367,17 @@ const handleInput = (currState) => {
       return;
     }
 
+    const updateDelta = firstPatch ? delta : new Delta(0, 0, 0);
     const update = new Update(
       Update.types.Edit,
-      delta,
+      updateDelta,
       version,
       patchStr,
     );
     update.send(ws);
 
     patchBuffer.push({ patchStr, delta });
+    firstPatch = false;
   });
 
   // Shift each active users' caret position and update the DOM with the new


### PR DESCRIPTION
Caret persistence and active user caret rendering handle new lines properly now. To get this working, I had to add special handling for typing in an empty conversation that adds a div around the typed content.

Also added a fix for when `diff-match-patch` generates a patch string with multiple patches in it. This breaks patches up into separate `Edit Update` messages, but it incorrectly gave them all the same delta. So I just updated it it to send a 0,0,0 delta for all but the first `Edit Update` message.